### PR TITLE
Add pipelines and organizations to seed Opfido 266

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,7 +77,8 @@ RUN mkdir /etc/services.d/0-rabbitmq \
   /etc/services.d/4-openfido-workflow-service \
   /etc/services.d/5-openfido-app-service \
   /etc/services.d/6-openfido-workflow-worker \
-  /etc/services.d/7-openfido-client
+  /etc/services.d/7-openfido-client \
+  /opt/app-keys
 
 ## AUTH
 
@@ -137,6 +138,7 @@ RUN chmod +x /tmp/minio && \
 ADD files/run-minio /etc/services.d/1-minio/run
 ADD files/minio-env /opt/minio/env
 
+VOLUME /var/opt/minio
 EXPOSE 9000/tcp
 
 # RABBITMQ
@@ -151,7 +153,6 @@ ADD files/run-postgres /etc/services.d/2-postgres/run
 ADD files/postgres-env /opt/postgres/env
 
 VOLUME /var/lib/postgresql/data
-
 EXPOSE 5432/tcp
 
 # SEED SCRIPT

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,7 +20,7 @@ The system will take a few minutes to bring up the underlying services and seed
 the initial system databases.
 
 Visit [http://127.0.0.1:3000](http://127.0.0.1:3000) and login with username `admin@example.com` and
-password `1234567890`.
+password `1234567890`. Several pipelines are created in an 'OpenFIDO' organization.
 
 Building
 --------
@@ -32,7 +32,7 @@ To build the image yourself, issue the following command:
 
     # Build the docker image, using the SSH private key you use for github
     # access (to access other openslac private repositories)
-    docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" -t openfido .
+    docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" -t openfido/openfido .
 
 
 Development
@@ -59,6 +59,7 @@ strictly necessary, but makes working with `git subtree` commands more concise):
     git remote add openfido-auth-service git@github.com:slacgismo/openfido-auth-service.git
     git remote add openfido-app-service git@github.com:slacgismo/openfido-app-service.git
     git remote add openfido-client git@github.com:slacgismo/openfido-client.git
+    git remote add openfido-utils git@github.com:slacgismo/openfido-utils.git
 
 
 NOTE: To simplify subtree merging be sure to commit any changes to these
@@ -73,6 +74,7 @@ subtree pull`. To pull changes from all dependent projects:
     git subtree pull --prefix=docker/openfido-auth-service openfido-auth-service master
     git subtree pull --prefix=docker/openfido-app-service openfido-app-service master
     git subtree pull --prefix=docker/openfido-client openfido-client master
+    git subtree pull --prefix=docker/openfido-utils openfido-utils master
 
 ### Pushing to original projects
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -60,6 +60,10 @@ strictly necessary, but makes working with `git subtree` commands more concise):
     git remote add openfido-app-service git@github.com:slacgismo/openfido-app-service.git
     git remote add openfido-client git@github.com:slacgismo/openfido-client.git
 
+
+NOTE: To simplify subtree merging be sure to commit any changes to these
+projects as individual commits.
+
 ### Pulling from upstream projects
 
 To pull in any changes from the original projects to this one, you can use `git

--- a/docker/files/run-app-service.sh
+++ b/docker/files/run-app-service.sh
@@ -2,6 +2,6 @@
 
 cd /opt/openfido-app-service
 source ./env
-source ./.env
+source /opt/app-keys/pipelines-client
 
 sh start.sh

--- a/docker/files/run-workflow-worker.sh
+++ b/docker/files/run-workflow-worker.sh
@@ -2,6 +2,6 @@
 
 cd /opt/openfido-workflow-service
 source ./worker-env
-source ./.worker-env
+source /opt/app-keys/worker-client
 
 celery -A app.worker worker -l DEBUG

--- a/docker/openfido-app-service/README.md
+++ b/docker/openfido-app-service/README.md
@@ -29,6 +29,8 @@ docker-compose which files to use, and where each project is:
 
     # Because these repositories make use of private github repositories, they
     # need access to an SSH key that you have configured for github access:
+    touch .worker-env
+    touch ../openfido-auth-service/.env
     docker-compose build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)"
 
     # Initialize all the databases for all the services:

--- a/docker/openfido-app-service/app/pipelines/services.py
+++ b/docker/openfido-app-service/app/pipelines/services.py
@@ -30,6 +30,18 @@ from .queries import (
 )
 
 
+def create_organization_pipeline(organization_uuid, pipeline_uuid):
+    """ Create OrganizationPipeline record. """
+    pipeline = OrganizationPipeline(
+        organization_uuid=organization_uuid,
+        pipeline_uuid=pipeline_uuid,
+    )
+    db.session.add(pipeline)
+    db.session.commit()
+
+    return pipeline
+
+
 def create_pipeline(organization_uuid, request_json):
     """ Create a new pipeline associated with an organization. """
     response = requests.post(
@@ -45,12 +57,7 @@ def create_pipeline(organization_uuid, request_json):
         json_value = response.json()
         response.raise_for_status()
 
-        pipeline = OrganizationPipeline(
-            organization_uuid=organization_uuid,
-            pipeline_uuid=json_value.get("uuid"),
-        )
-        db.session.add(pipeline)
-        db.session.commit()
+        pipeline = create_organization_pipeline(organization_uuid, json_value.get("uuid"))
 
         json_value["uuid"] = pipeline.uuid
         return json_value

--- a/docker/openfido-app-service/app/pipelines/services.py
+++ b/docker/openfido-app-service/app/pipelines/services.py
@@ -57,7 +57,9 @@ def create_pipeline(organization_uuid, request_json):
         json_value = response.json()
         response.raise_for_status()
 
-        pipeline = create_organization_pipeline(organization_uuid, json_value.get("uuid"))
+        pipeline = create_organization_pipeline(
+            organization_uuid, json_value.get("uuid")
+        )
 
         json_value["uuid"] = pipeline.uuid
         return json_value

--- a/docker/openfido-app-service/tasks.py
+++ b/docker/openfido-app-service/tasks.py
@@ -62,3 +62,16 @@ def create_application_key(c, name, permission):
         application = create_application(name, ApplicationsEnum[permission])
         db.session.commit()
         print(f"API_TOKEN={application.api_key}")
+
+
+@task
+def create_organization_pipeline(c, organization_uuid, pipeline_uuid):
+    """Create an organization pipeline, that is associated with a pipeline_uuid.
+    """
+    from app import create_app
+    from app.pipelines.services import create_organization_pipeline
+
+    (app, db, _) = create_app()
+    with app.app_context():
+        organization_pipeline = create_organization_pipeline(organization_uuid, pipeline_uuid)
+        print(organization_pipeline.uuid)

--- a/docker/openfido-auth-service/README.md
+++ b/docker/openfido-auth-service/README.md
@@ -50,7 +50,7 @@ have [docker](https://docs.docker.com/get-docker/) and [docker-compose](https://
     cp .env.example .env
 
     # Login to an docker instance of the flask app:
-    docker-compose run --rm auth_service bash
+    docker-compose run --rm auth-service bash
 
     # Run database migrations
     flask db upgrade
@@ -76,10 +76,10 @@ To connect to the database:
     docker-compose exec db psql -d accountservices -U postgres
 
 
-To connect to a shell in the auth_service container:
+To connect to a shell in the auth-service container:
     
     # while docker-compose is running:
-    docker-compose exec auth_service bash
+    docker-compose exec auth-service bash
 
 To connect to a shell in the db container:
     
@@ -89,23 +89,23 @@ To connect to a shell in the db container:
 To run tests, use [invoke](https://pyinvoke.org):
 
     # Run within the preconfigured docker instance:
-    docker-compose run --rm auth_service invoke test
+    docker-compose run --rm auth-service invoke test
 
     # with code coverage
-    docker-compose run --rm auth_service invoke test --cov-report && open htmlcov/index.html
+    docker-compose run --rm auth-service invoke test --cov-report && open htmlcov/index.html
 
     # Or if you'd rather run locally
     pipenv install
     pipenv run invoke test
 
     # to run a lint test
-    docker-compose run --rm auth_service invoke lint
+    docker-compose run --rm auth-service invoke lint
 
     # to check code style
-    docker-compose run --rm auth_service invoke style
+    docker-compose run --rm auth-service invoke style
 
     # to auto-correct code style errors
-    docker-compose run --rm auth_service invoke style --fix
+    docker-compose run --rm auth-service invoke style --fix
 
 Other tasks are available, in particular the `precommit` task, which mirrors the
 tests performed by CircleCI.

--- a/docker/openfido-auth-service/docker-compose.yml
+++ b/docker/openfido-auth-service/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  auth_db:
+  auth-db:
     image: postgres:11
     environment:
       POSTGRES_DB: accountservices
@@ -15,7 +15,7 @@ services:
       - ${AUTH_DIR:-.}/uploads:/data:delegated
     ports:
       - "9000:9000"
-  auth_service:
+  auth-service:
     build: ${AUTH_DIR:-.}
     command: flask run -h 0.0.0.0
     env_file:
@@ -23,11 +23,11 @@ services:
     environment:
       PGDATABASE: accountservices
       PGUSER: postgres
-      PGHOST: auth_db
+      PGHOST: auth-db
       FLASK_APP: run.py
       FLASK_ENV: development
       SECRET_KEY: local-dev-db
-      SQLALCHEMY_DATABASE_URI: "postgresql://postgres:dev-password@auth_db/accountservices"
+      SQLALCHEMY_DATABASE_URI: "postgresql://postgres:dev-password@auth-db/accountservices"
       S3_ACCESS_KEY_ID: minio_access_key
       S3_SECRET_ACCESS_KEY: minio123
       S3_BUCKET: openfido-data
@@ -39,5 +39,5 @@ services:
     ports:
       - "${AUTH_PORT:-5000}:5000"
     depends_on:
-      - auth_db
+      - auth-db
       - authstorage

--- a/docker/openfido-auth-service/tasks.py
+++ b/docker/openfido-auth-service/tasks.py
@@ -44,3 +44,29 @@ def precommit(c, fix=False):
     test(c, junit=True, enforce_percent=92)
     style(c, fix=fix)
     lint(c, fail_under=9)
+
+
+@task
+def create_user(c, email, password, first_name, last_name, is_system_admin=False):
+    """ Create a user. Returns the UUID of the organization. """
+    from app import create_app, models, services
+
+    (app, db, _) = create_app()
+    with app.app_context():
+        user = services.create_user(email, password, first_name, last_name)
+        user.is_system_admin = is_system_admin
+        models.db.session.commit()
+        print(user.uuid)
+
+
+@task
+def create_organization(c, name, email):
+    """ Create an organization for a user with 'email'. Returns the UUID of the organization. """
+    from app import create_app, models, services, queries
+
+    (app, db, _) = create_app()
+    with app.app_context():
+        user = queries.find_user_by_email(email)
+        organization = services.create_organization(name, user)
+        models.db.session.commit()
+        print(organization.uuid)

--- a/docker/openfido-workflow-service/README.md
+++ b/docker/openfido-workflow-service/README.md
@@ -34,7 +34,7 @@ have [docker](https://docs.docker.com/get-docker/) and [docker-compose](https://
     # parameter - until then we need to pass the key manually :(
 
     # Login to an docker instance of the flask app:
-    docker-compose run --rm workflow_service bash
+    docker-compose run --rm workflow-service bash
 
     # Run database migrations
     flask db upgrade
@@ -58,10 +58,10 @@ To start the server locally:
 To run tests, use [invoke](https://pyinvoke.org):
 
     # Run within the preconfigured docker instance:
-    docker-compose run --rm workflow_service invoke test
+    docker-compose run --rm workflow-service invoke test
 
     # with code coverage
-    docker-compose run --rm workflow_service invoke --cov-report test
+    docker-compose run --rm workflow-service invoke --cov-report test
 
     # Or if you'd rather run locally
     pipenv install

--- a/docker/openfido-workflow-service/docker-compose.yml
+++ b/docker/openfido-workflow-service/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  workflow_queue:
+  workflow-queue:
     build:
       context: ${WORKFLOW_DIR:-.}
       dockerfile: Dockerfile.rabbitmq
@@ -9,7 +9,7 @@ services:
       RABBITMQ_DEFAULT_USER: rabbit-user
       RABBITMQ_DEFAULT_PASS: rabbit-password
       RABBITMQ_DEFAULT_VHOST: api-queue
-  workflow_db:
+  workflow-db:
     image: postgres:11
     environment:
       POSTGRES_DB: workflowservice
@@ -24,19 +24,19 @@ services:
       - ${WORKFLOW_DIR:-.}/uploads:/data:delegated
     ports:
       - "9000:9000"
-  workflow_service:
+  workflow-service:
     build: ${WORKFLOW_DIR:-.}
     image: openfido/dev-workflow
     command: flask run -h 0.0.0.0
     environment:
       PGDATABASE: workflowservice
       PGUSER: postgres
-      PGHOST: workflow_db
+      PGHOST: workflow-db
       FLASK_APP: run.py
       FLASK_ENV: development
       SECRET_KEY: local-dev-db
-      SQLALCHEMY_DATABASE_URI: postgresql://postgres:dev-password@workflow_db/workflowservice
-      CELERY_BROKER_URL: amqp://rabbit-user:rabbit-password@workflow_queue/api-queue
+      SQLALCHEMY_DATABASE_URI: postgresql://postgres:dev-password@workflow-db/workflowservice
+      CELERY_BROKER_URL: amqp://rabbit-user:rabbit-password@workflow-queue/api-queue
       S3_ACCESS_KEY_ID: minio_access_key
       S3_SECRET_ACCESS_KEY: minio123
       S3_ENDPOINT_URL: http://workflowstorage:9000
@@ -47,18 +47,18 @@ services:
     ports:
       - "${WORKFLOW_PORT:-5000}:5000"
     depends_on:
-      - workflow_db
-      - workflow_queue
+      - workflow-db
+      - workflow-queue
       - workflowstorage
-  workflow_worker:
+  workflow-worker:
     build:
       context: ${WORKFLOW_DIR:-.}
       dockerfile: Dockerfile.worker
     image: openfido/dev-workflow-worker
     command: celery -A app.worker worker -l DEBUG
     environment:
-      CELERY_BROKER_URL: amqp://rabbit-user:rabbit-password@workflow_queue/api-queue
-      WORKER_API_SERVER: http://workflow_service:${WORKFLOW_PORT:-5000}
+      CELERY_BROKER_URL: amqp://rabbit-user:rabbit-password@workflow-queue/api-queue
+      WORKER_API_SERVER: http://workflow-service:${WORKFLOW_PORT:-5000}
       S3_ACCESS_KEY_ID: minio_access_key
       S3_SECRET_ACCESS_KEY: minio123
       S3_ENDPOINT_URL: http://workflowstorage:9000
@@ -73,6 +73,6 @@ services:
       # found).
       - /tmp:/tmp
     depends_on:
-      - workflow_queue
-      - workflow_service
+      - workflow-queue
+      - workflow-service
       - workflowstorage

--- a/docker/openfido-workflow-service/tasks.py
+++ b/docker/openfido-workflow-service/tasks.py
@@ -97,3 +97,21 @@ def run_worker(c, input_directory, docker_image, repository_url, repository_bran
                          repository_branch,
                          repository_script)
     fake_execute()
+
+
+@task
+def create_pipeline(c, name, docker_image_url, repository_ssh_url, repository_branch='master', repository_script='openfido.sh'):
+    """ Create a pipeline. """
+    from app import create_app
+    from app.pipelines.services import create_pipeline
+
+    (app, db, _, _) = create_app()
+    with app.app_context():
+        pipeline = create_pipeline({
+            'name': name,
+            'docker_image_url': docker_image_url,
+            'repository_ssh_url': repository_ssh_url,
+            'repository_branch': repository_branch,
+            'repository_script': repository_script,
+        })
+        print(pipeline.uuid)

--- a/terraform/provisioning.md
+++ b/terraform/provisioning.md
@@ -4,6 +4,8 @@ Run terragrunt for a specific environment to create AWS:
 
 TODO show commands needed to create environment.
 
+TODO include docs for configuring the AWS --profile setting for the account.
+
 # Configuration
 
 Once the infrastructure has been stood up, the databases and initial accounts


### PR DESCRIPTION
This includes changes to the three services, to expose CLI commands to make it possible to create these organizations/pipelines from the CLI without the services being up yet. I've used `git subtree push` to make PRs for them:
 * https://github.com/slacgismo/openfido-workflow-service/pull/27
 * https://github.com/slacgismo/openfido-auth-service/pull/12
 * https://github.com/slacgismo/openfido-app-service/pull/38