### PR TITLE
Fixed issue with ICA example chart display

### DIFF
--- a/docker/openfido-client/src/util/charts.js
+++ b/docker/openfido-client/src/util/charts.js
@@ -18,7 +18,7 @@ const DATE_FORMATS = [
 ];
 
 export const toUnixTime = (str) => moment(str, DATE_FORMATS).unix();
-export const validDateString = (str) => moment(str, DATE_FORMATS).isValid();
+export const validDateString = (str) => moment(str, DATE_FORMATS, true).isValid();
 
 export const getLimitedDataPointsForGraph = ({
   data,
@@ -84,7 +84,6 @@ export const parseCsvData = (data) => {
       .on('error', reject)
       .on('data', (row) => {
         const rowData = { ...row };
-
         Object.keys(rowData).forEach((column) => {
           if (rowData[column].match(/^[+-]?\d+([,.]\d+)?(e[+-]\d+)?$/)) {
             rowData[column] = parseFloat(rowData[column]);


### PR DESCRIPTION
This frontend change fixes the issue with the ICA chart display. The missing part ("true") in the moments date check method allowed for this csv data to be processed as timestamp - which now is corrected.

The CSV contents for solar_capacity.csv:
<img width="257" alt="Screen Shot 2021-01-31 at 9 02 40 PM" src="https://user-images.githubusercontent.com/42715836/106417235-60b62d80-6408-11eb-9a94-4d42603f9ce8.png">

Previously, the bar chart for solar_capacity.csv looked like this:
<img width="988" alt="Screen Shot 2021-01-31 at 9 03 52 PM" src="https://user-images.githubusercontent.com/42715836/106417210-52681180-6408-11eb-8e5e-544beb102bc7.png">

With this change, the bar chart for solar_capacity now displays correctly:
<img width="990" alt="Screen Shot 2021-01-31 at 9 08 56 PM" src="https://user-images.githubusercontent.com/42715836/106417291-8b07eb00-6408-11eb-99f5-7943c6fe9d7a.png">
